### PR TITLE
Android: InputTypes.ClassText | InputTypes.TextVariationEmailAddress for Email case

### DIFF
--- a/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
@@ -185,7 +185,7 @@ namespace Acr.UserDialogs {
             switch (inputType) {
 
                 case InputType.Email:
-                    txt.InputType = InputTypes.TextVariationEmailAddress;
+                    txt.InputType = InputTypes.ClassText | InputTypes.TextVariationEmailAddress;
                     break;
 
 				case InputType.Name:


### PR DESCRIPTION
On Android 4.4 JellyBean with ```PromptConfig.InputType = InputType.Email``` the keyboard didn't show **@** character. Changing ```txt.InputType = InputTypes.TextVariationEmailAddress;``` to ```txt.InputType = InputTypes.ClassText | InputTypes.TextVariationEmailAddress;``` seems to work. 

Didn't test if the problem persists on other devices/versions.

[http://developer.android.com/reference/android/widget/TextView.html#attr_android:inputType](http://developer.android.com/reference/android/widget/TextView.html#attr_android:inputType) textview inputType of textEmailAddress corresponds to the above fix.