### PR TITLE
Fix for #28

### DIFF
--- a/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
@@ -345,9 +345,15 @@ namespace Acr.UserDialogs {
                 return nav.VisibleViewController;
 
             if (root.PresentedViewController != null)
-                return root.PresentedViewController;
+                return this.GetCorrectPresentedViewController(root.PresentedViewController);
 
             return root;
+        }
+
+        private UIViewController GetCorrectPresentedViewController(UIViewController viewController) {
+            if (viewController.PresentedViewController != null)
+                return this.GetCorrectPresentedViewController(viewController.PresentedViewController);
+            return viewController;
         }
     }
 }


### PR DESCRIPTION
This makes the search for the top view controller recursive so when you have a modal stack over one the dialog appear correctly.