### PR TITLE
ability to init from a custom Application, not only the first Activity

### DIFF
--- a/src/Acr.UserDialogs.Android/ActivityLifecycleCallbacks.cs
+++ b/src/Acr.UserDialogs.Android/ActivityLifecycleCallbacks.cs
@@ -3,32 +3,57 @@ using Android.App;
 using Android.OS;
 
 
-namespace Acr.UserDialogs {
+namespace Acr.UserDialogs
+{
 
-    public class ActivityLifecycleCallbacks : Java.Lang.Object, Application.IActivityLifecycleCallbacks {
+	public class ActivityLifecycleCallbacks : Java.Lang.Object, Application.IActivityLifecycleCallbacks
+	{
 
-        public static void Register(Activity activity) {
-            activity.Application.RegisterActivityLifecycleCallbacks(new ActivityLifecycleCallbacks());
-            CurrentTopActivity = activity;
-        }
+		public static void Register (Activity activity)
+		{
+			activity.Application.RegisterActivityLifecycleCallbacks (new ActivityLifecycleCallbacks ());
+			CurrentTopActivity = activity;
+		}
 
-        public static Activity CurrentTopActivity { get; protected set; }
+		public static void Register (Application application)
+		{
+			application.RegisterActivityLifecycleCallbacks (new ActivityLifecycleCallbacks ());
+			CurrentTopActivity = null;
+		}
 
-
-        public virtual void OnActivityCreated(Activity activity, Bundle savedInstanceState) {
-            CurrentTopActivity = activity;
-        }
-
-
-        public virtual void OnActivityResumed(Activity activity) {
-            CurrentTopActivity = activity;
-        }
+		public static Activity CurrentTopActivity { get; protected set; }
 
 
-        public virtual void OnActivityPaused(Activity activity) {}
-        public virtual void OnActivityDestroyed(Activity activity) {}
-        public virtual void OnActivitySaveInstanceState(Activity activity, Bundle outState) {}
-        public virtual void OnActivityStarted(Activity activity) {}
-        public virtual void OnActivityStopped(Activity activity) {}
-    }
+		public virtual void OnActivityCreated (Activity activity, Bundle savedInstanceState)
+		{
+			CurrentTopActivity = activity;
+		}
+
+
+		public virtual void OnActivityResumed (Activity activity)
+		{
+			CurrentTopActivity = activity;
+		}
+
+
+		public virtual void OnActivityPaused (Activity activity)
+		{
+		}
+
+		public virtual void OnActivityDestroyed (Activity activity)
+		{
+		}
+
+		public virtual void OnActivitySaveInstanceState (Activity activity, Bundle outState)
+		{
+		}
+
+		public virtual void OnActivityStarted (Activity activity)
+		{
+		}
+
+		public virtual void OnActivityStopped (Activity activity)
+		{
+		}
+	}
 }

--- a/src/Acr.UserDialogs.Shared/UserDialogs.cs
+++ b/src/Acr.UserDialogs.Shared/UserDialogs.cs
@@ -1,39 +1,55 @@
 ﻿using System;
 
 
-namespace Acr.UserDialogs {
+namespace Acr.UserDialogs
+{
 
-    public static class UserDialogs {
+	public static class UserDialogs
+	{
 
-        static readonly Lazy<IUserDialogs> instance = new Lazy<IUserDialogs>(() => {
+		static readonly Lazy<IUserDialogs> instance = new Lazy<IUserDialogs> (() => {
 #if PCL
             throw new ArgumentException("This PCL library, not the platform library.  Did you include the nuget package in your project?");
 #elif __ANDROID__
-            throw new ArgumentException("In android, you must call UserDialogs.Init(Activity) from your first activity");
+			throw new ArgumentException ("In android, you must call UserDialogs.Init(Activity) from your first activity");
 #else
             return new UserDialogsImpl();
 #endif
-        });
+		});
 
-#if __ANDROID__
+		#if __ANDROID__
 
 
-        /// <summary>
-        /// Initialize android user dialogs
-        /// </summary>
-        public static void Init(Android.App.Activity activity, bool useAppCompat = false) {
-            ActivityLifecycleCallbacks.Register(activity);
-            if (useAppCompat)
-                Instance = new AppCompatUserDialogsImpl(null);
-            else
-                Instance = new UserDialogsImpl(null);
-        }
-#endif
+		/// <summary>
+		/// Initialize android user dialogs
+		/// </summary>
+		public static void Init (Android.App.Activity activity, bool useAppCompat = false)
+		{
+			ActivityLifecycleCallbacks.Register (activity);
+			if (useAppCompat)
+				Instance = new AppCompatUserDialogsImpl (null);
+			else
+				Instance = new UserDialogsImpl (null);
+		}
 
-        static IUserDialogs customInstance;
-        public static IUserDialogs Instance {
-            get { return customInstance ?? instance.Value; }
-            set { customInstance = value; }
-        }
-    }
+		/// <summary>
+		/// Initialize android user dialogs
+		/// </summary>
+		public static void Init (Android.App.Application application, bool useAppCompat = false)
+		{
+			ActivityLifecycleCallbacks.Register (application);
+			if (useAppCompat)
+				Instance = new AppCompatUserDialogsImpl (null);
+			else
+				Instance = new UserDialogsImpl (null);
+		}
+		#endif
+
+		static IUserDialogs customInstance;
+
+		public static IUserDialogs Instance {
+			get { return customInstance ?? instance.Value; }
+			set { customInstance = value; }
+		}
+	}
 }


### PR DESCRIPTION
hey man, so, I had an issue with Acr.UserDialogs, I wanted to init it from a custom Android Application (before any Activity then) and also register the .Instance to DI at the same place (still before any Activity)
but the Init() needed an activity and the .Instance needed the Init() to be executed.
so I added a way to init from Application, what do you think ?
(sorry for the line reordering, XS did it automagically)