### PR TITLE
Change order of cancel and OK buttons in iOS prompt

### DIFF
--- a/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
@@ -255,18 +255,18 @@ namespace Acr.UserDialogs {
 			var dlg = UIAlertController.Create(config.Title ?? String.Empty, config.Message, UIAlertControllerStyle.Alert);
 			UITextField txt = null;
 
-			dlg.AddAction(UIAlertAction.Create(config.OkText, UIAlertActionStyle.Default, x => {
-				result.Ok = true;
-				result.Text = txt.Text.Trim();
-				config.OnResult(result);
-			}));
 			if (config.IsCancellable) {
-				dlg.AddAction(UIAlertAction.Create(config.CancelText, UIAlertActionStyle.Default, x => {
+				dlg.AddAction(UIAlertAction.Create(config.CancelText, UIAlertActionStyle.Cancel, x => {
 					result.Ok = false;
 					result.Text = txt.Text.Trim();
 					config.OnResult(result);
 				}));
 			}
+			dlg.AddAction(UIAlertAction.Create(config.OkText, UIAlertActionStyle.Default, x => {
+				result.Ok = true;
+				result.Text = txt.Text.Trim();
+				config.OnResult(result);
+			}));
 			dlg.AddTextField(x => {
 				this.SetInputType(x, config.InputType);
 				x.Placeholder = config.Placeholder ?? String.Empty;


### PR DESCRIPTION
Contains the following changes:

- show OK action on the right and cancel on the left
- change appearance of cancel button to UIAlertActionStyle.Cancel

This follows the [iOS Human Interface Guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/Alerts.html#//apple_ref/doc/uid/TP40006556-CH14-SW1):

> When the most likely button performs a nondestructive action, it should be on the right in a two-button alert. The button that cancels this action should be on the left.