### PR TITLE
Small fix for the incorrect reference to v7 AppCompact

### DIFF
--- a/src/Acr.UserDialogs.Android.AppCompat/Acr.UserDialogs.Android.AppCompat.csproj
+++ b/src/Acr.UserDialogs.Android.AppCompat/Acr.UserDialogs.Android.AppCompat.csproj
@@ -58,7 +58,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.23.1.1.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
Manually updated the reference to the incorrect v7 project. Xamarin Studio didn't pick up that mistake. 