### PR TITLE
[Android] Close the input dialog on 'Enter' key

### DIFF
--- a/src/Acr.UserDialogs.Android/Extensions.cs
+++ b/src/Acr.UserDialogs.Android/Extensions.cs
@@ -35,7 +35,7 @@ namespace Acr.UserDialogs {
         }
 
 #else
-		public static Android.App.AlertDialog ShowExt(this Android.App.AlertDialog.Builder builder) {
+        public static Android.App.AlertDialog ShowExt(this Android.App.AlertDialog.Builder builder) {
             var dialog = builder.Create();
             dialog.Window.SetSoftInputMode(SoftInput.StateVisible);
             dialog.Show();

--- a/src/Acr.UserDialogs.Android/Extensions.cs
+++ b/src/Acr.UserDialogs.Android/Extensions.cs
@@ -27,17 +27,19 @@ namespace Acr.UserDialogs {
         }
 
 #if APPCOMPAT
-        public static void ShowExt(this Android.Support.V7.App.AlertDialog.Builder builder) {
+        public static Android.Support.V7.App.AlertDialog ShowExt(this Android.Support.V7.App.AlertDialog.Builder builder) {
             var dialog = builder.Create();
             dialog.Window.SetSoftInputMode(SoftInput.StateVisible);
             dialog.Show();
+            return dialog
         }
 
 #else
-        public static void ShowExt(this Android.App.AlertDialog.Builder builder) {
+		public static Android.App.AlertDialog ShowExt(this Android.App.AlertDialog.Builder builder) {
             var dialog = builder.Create();
             dialog.Window.SetSoftInputMode(SoftInput.StateVisible);
             dialog.Show();
+            return dialog;
         }
 #endif
     }

--- a/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
@@ -147,22 +147,21 @@ namespace Acr.UserDialogs {
                     Hint = config.Placeholder
                 };
 
-				EventHandler<View.KeyEventArgs> keyHandler = null;
-				var successFunc = new Action<bool>(success =>
-				{
-					if (keyHandler != null)
-					{
-						txt.KeyPress -= keyHandler;
-					}
+                EventHandler<View.KeyEventArgs> keyHandler = null;
+                var successFunc = new Action<bool>(success =>
+                {
+                    if (keyHandler != null)
+                    {
+                        txt.KeyPress -= keyHandler;
+                    }
 
-					config.OnResult(new PromptResult
-					{
-						Ok = success,
-						Text = txt.Text
-					});
-				});
-				if (config.Text != null)
-					txt.Text = config.Text;
+                    config.OnResult(new PromptResult {
+                        Ok = success,
+                        Text = txt.Text
+                    });
+                });
+                if (config.Text != null)
+                    txt.Text = config.Text;
 
                 this.SetInputType(txt, config.InputType);
 
@@ -174,9 +173,9 @@ namespace Acr.UserDialogs {
                     .SetView(txt)
                     .SetPositiveButton(config.OkText, (s, a) => successFunc(true));
 
-				if (config.IsCancellable) {
-					builder.SetNegativeButton(config.CancelText, (s, a) => successFunc(false));
-				}
+                if (config.IsCancellable) {
+                    builder.SetNegativeButton(config.CancelText, (s, a) => successFunc(false));
+                }
 
                 var dialog = builder.ShowExt();
                 keyHandler = new EventHandler<View.KeyEventArgs>((sender, e) =>


### PR DESCRIPTION
This PR addresses an inconsistency in handling hardware 'Enter' on iOS and Android when input prompt is shown.

On iOS when a hardware keyboard is attached, the 'Enter' key acts as if the 'Ok' button is pressed. I've tried to bridge the consistency gap by handling hardware 'Enter' and closing the dialog in Android.

Let me know what you think.