### PR TITLE
Toast position read/write. iOS routine to hide all toasts

### DIFF
--- a/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.Android/UserDialogsImpl.cs
@@ -163,6 +163,11 @@ namespace Acr.UserDialogs
                 this.ToastAppCompat(compat, cfg);
         }
 
+        public override void ToastHideAll()
+        {
+            
+        }
+
 
         protected virtual void ToastAppCompat(AppCompatActivity activity, ToastConfig cfg)
         {

--- a/src/Acr.UserDialogs.Interface/AbstractUserDialogs.cs
+++ b/src/Acr.UserDialogs.Interface/AbstractUserDialogs.cs
@@ -21,6 +21,7 @@ namespace Acr.UserDialogs
         public abstract void ShowError(string message, int timeoutMillis);
         public abstract void ShowSuccess(string message, int timeoutMillis);
         public abstract void Toast(ToastConfig config);
+        public abstract void ToastHideAll();
         protected abstract IProgressDialog CreateDialogInstance();
 
 

--- a/src/Acr.UserDialogs.Interface/ToastConfig.cs
+++ b/src/Acr.UserDialogs.Interface/ToastConfig.cs
@@ -56,7 +56,7 @@ namespace Acr.UserDialogs
         /// <summary>
         /// Only applies to iOS at the moment
         /// </summary>
-        public ToastPosition Position { get; }
+        public ToastPosition Position { get; set; }
         public Color BackgroundColor { get; set; }
         public IBitmap Icon { get; set; }
         public string Title { get; set; }

--- a/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
@@ -23,8 +23,7 @@ namespace Acr.UserDialogs
             this.toastTimer = new Timer();
             this.toastTimer.Elapsed += (sender, args) =>
             {
-                this.toastTimer.Stop();
-                UIApplication.SharedApplication.InvokeOnMainThread(MessageBarManager.SharedInstance.HideAll);
+                ToastHideAll();
             };
         }
 
@@ -175,6 +174,12 @@ namespace Acr.UserDialogs
                 this.toastTimer.Interval = cfg.Duration.TotalMilliseconds;
                 this.toastTimer.Start();
             });
+        }
+
+        public override void ToastHideAll()
+        {
+            this.toastTimer.Stop();
+            UIApplication.SharedApplication.InvokeOnMainThread(MessageBarManager.SharedInstance.HideAll);
         }
 
 


### PR DESCRIPTION
In iOS it is advantageous to be able to hide all toasts. Often when a toast is showing a user can still navigate around the app and the toast may no long be applicable.