### PR TITLE
Add destructive action sheet button first

### DIFF
--- a/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.iOS/UserDialogsImpl.cs
@@ -40,13 +40,14 @@ namespace Acr.UserDialogs
         public override IDisposable ActionSheet(ActionSheetConfig config)
         {
             var sheet = UIAlertController.Create(config.Title, null, UIAlertControllerStyle.ActionSheet);
+
+            if (config.Destructive != null)
+                this.AddActionSheetOption(config.Destructive, sheet, UIAlertActionStyle.Destructive);
+
             config
                 .Options
                 .ToList()
                 .ForEach(x => this.AddActionSheetOption(x, sheet, UIAlertActionStyle.Default, config.ItemIcon));
-
-            if (config.Destructive != null)
-                this.AddActionSheetOption(config.Destructive, sheet, UIAlertActionStyle.Destructive);
 
             if (config.Cancel != null)
                 this.AddActionSheetOption(config.Cancel, sheet, UIAlertActionStyle.Cancel);


### PR DESCRIPTION
Apple's iOS Human Interface Guidelines suggest placing destructive actions at the top.
https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/Alerts.html