### PR TITLE
Use 24 hours format in TimePicker based on settings

### DIFF
--- a/src/Acr.UserDialogs.Android/Builders/TimePromptBuilder.cs
+++ b/src/Acr.UserDialogs.Android/Builders/TimePromptBuilder.cs
@@ -25,8 +25,8 @@ namespace Acr.UserDialogs.Builders
                 picker.CurrentMinute = new Integer(config.SelectedTime.Value.Minutes);
             }
 
-			var is24Hours = DateFormat.Is24HourFormat(activity);
-			picker.SetIs24HourView(new Boolean(is24Hours));
+            var is24Hours = DateFormat.Is24HourFormat(activity);
+            picker.SetIs24HourView(new Boolean(is24Hours));
 
             if (config.IsCancellable)
             {

--- a/src/Acr.UserDialogs.Android/Builders/TimePromptBuilder.cs
+++ b/src/Acr.UserDialogs.Android/Builders/TimePromptBuilder.cs
@@ -1,7 +1,9 @@
 using System;
 using Android.App;
+using Android.Text.Format;
 using Android.Widget;
 using Java.Lang;
+using Boolean = Java.Lang.Boolean;
 
 
 namespace Acr.UserDialogs.Builders
@@ -22,6 +24,9 @@ namespace Acr.UserDialogs.Builders
                 picker.CurrentHour = new Integer(config.SelectedTime.Value.Hours);
                 picker.CurrentMinute = new Integer(config.SelectedTime.Value.Minutes);
             }
+
+			var is24Hours = DateFormat.Is24HourFormat(activity);
+			picker.SetIs24HourView(new Boolean(is24Hours));
 
             if (config.IsCancellable)
             {


### PR DESCRIPTION
The Android TimePickerdialog does not take your datetime settings into account and always shows an am/pm clock. iOS does this based on your locale, however the Android API lets you set it explicitly.

I've copied iOS behavior by checking what the user has set in their settings, for reference see https://developer.android.com/reference/android/text/format/DateFormat.html#is24HourFormat%28android.content.Context%29