### PR TITLE
UWP ProgressContentDialog height issue fix

### DIFF
--- a/src/Acr.UserDialogs.Uwp/ProgressContentDialog.xaml
+++ b/src/Acr.UserDialogs.Uwp/ProgressContentDialog.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    MinHeight="0"
     Background="Black"
     Opacity="0.7">
 


### PR DESCRIPTION
It is little but annoying visual problem, ProgressContentDialog.xaml has MinHeight value as 184. Therefore, if anyone call the showloading function with simple text it appears like this,

http://prntscr.com/buf7ai

with this change,

http://prntscr.com/buf8cw