### PR TITLE
Fix Prompt message text not wrapping in UWP

### DIFF
--- a/src/Acr.UserDialogs.Uwp/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs.Uwp/UserDialogsImpl.cs
@@ -209,7 +209,7 @@ namespace Acr.UserDialogs
         {
             var stack = new StackPanel();
             if (!String.IsNullOrWhiteSpace(config.Message))
-                stack.Children.Add(new TextBlock { Text = config.Message });
+                stack.Children.Add(new TextBlock { Text = config.Message, TextWrapping = TextWrapping.WrapWholeWords });
 
             var dialog = new ContentDialog
             {


### PR DESCRIPTION
Minor cosmetic fix--for whatever reason, the TextBlock used to display the message in a Prompt defaults to a TextWrapping value of NoWrap.

Also, I noticed that in the UWP project, you have a PromptDialog control, but the code doesn't actually use it. Is that an artifact from a previous design, or something you're intending to use in the future? I.E. should I adjust this PR to work with the PromptDialog control?