### PR TITLE
CancelationToken registration fix

### DIFF
--- a/src/Samples/Samples/ViewModels/SpecificCasesViewModel.cs
+++ b/src/Samples/Samples/ViewModels/SpecificCasesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Acr.UserDialogs;
 using Xamarin.Forms;
@@ -91,6 +92,24 @@ namespace Samples.ViewModels
                             TaskCreationOptions.LongRunning
                         )
                     )
+                },
+                new CommandViewModel
+                {
+                    Text = "Two alerts with one Cancellation Token Source",
+                    Command = new Command(async () =>
+                    {
+                        try
+                        {
+                            var cts = new CancellationTokenSource();
+
+                            await this.Dialogs.AlertAsync("Press ok and then wait", "Hi", null, cts.Token);
+                            cts.CancelAfter(TimeSpan.FromSeconds(3));
+                            await this.Dialogs.AlertAsync("I'll close soon, just wait", "Hi", null, cts.Token);
+                        }
+                        catch(OperationCanceledException)
+                        {
+                        }
+                    })
                 },
                 new CommandViewModel
                 {


### PR DESCRIPTION
This PR adds proper cleanup of CancellationTokenRegistations by wrapping `CancellationToken.Register()` into a using.

1. checkout `415c7bb` and add a breakpoint at Android UserDialogsImpl.cs:344
2. compile and tap on new example (Specific cases -> Two alerts with one Cancellation Token Source)
3. tap Ok
4. wait until second dialog gets dismissed
5. count breakpoint hits (you will count 2 hits,but it should only be one, because the first dialog has been closed)
6. checkout `5b42c4d`
7. do 2-5. (you will count 1 hit)

Because of the missing deregistration, you could end up with some memory leaks because of the captured closure in all `CancellationToken.Register()`.

see: [MSDN: How to: Register Callbacks for Cancellation Requests](https://msdn.microsoft.com/en-us/library/ee191554(v=vs.110).aspx)