### PR TITLE
#348 make toast height dynamic to expand if needed

### DIFF
--- a/src/Acr.UserDialogs.iOS/TTGSnackbar.cs
+++ b/src/Acr.UserDialogs.iOS/TTGSnackbar.cs
@@ -269,7 +269,7 @@ namespace TTG
 				heightConstraint = NSLayoutConstraint.Create(
 					this,
 					NSLayoutAttribute.Height,
-					NSLayoutRelation.Equal,
+					NSLayoutRelation.GreaterThanOrEqual,
 					null,
 					NSLayoutAttribute.NoAttribute,
 					1,


### PR DESCRIPTION
This will fix #348 and make toast height to expand if a text message longer than 2 lines is set.