### PR TITLE
Changed title behaviour for date prompts (issue #386)

### DIFF
--- a/src/Acr.UserDialogs.Android/AcrDatePickerDialog.cs
+++ b/src/Acr.UserDialogs.Android/AcrDatePickerDialog.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Android.App;
+using Android.Content;
+using Android.Widget;
+using String = System.String;
+
+namespace Acr.UserDialogs
+{
+    public class AcrDatePickerDialog : DatePickerDialog
+    {
+        private readonly string _title;
+
+        public AcrDatePickerDialog(Context context, int theme, EventHandler<DateSetEventArgs> callBack, int year, int monthOfYear, int dayOfMonth, string title) : base(context, theme, callBack, year, monthOfYear, dayOfMonth)
+        {
+            _title = title;
+        }
+
+        public override void OnDateChanged(DatePicker view, int year, int month, int dayOfMonth)
+        {
+            if (!String.IsNullOrWhiteSpace(_title))
+                SetTitle(_title);
+        }
+    }
+}

--- a/src/Acr.UserDialogs.Android/Builders/DatePromptBuilder.cs
+++ b/src/Acr.UserDialogs.Android/Builders/DatePromptBuilder.cs
@@ -11,18 +11,16 @@ namespace Acr.UserDialogs.Builders
         public static DatePickerDialog Build(Activity activity, DatePromptConfig config)
         {
             var dateTime = config.SelectedDate ?? DateTime.Now;
-            var dialog = new DatePickerDialog(
+            var dialog = new AcrDatePickerDialog(
                 activity,
                 config.AndroidStyleId ?? 0,
                 (sender, args) => { },
                 dateTime.Year,
                 dateTime.Month - 1,
-                dateTime.Day
+                dateTime.Day,
+                config.Title
             );
             dialog.SetCancelable(false);
-
-            if (!String.IsNullOrWhiteSpace(config.Title))
-                dialog.SetTitle(config.Title);
 
             if (config.MinimumDate != null)
                 dialog.DatePicker.MinDate = config.MinimumDate.Value.ToUnixTimestamp();


### PR DESCRIPTION
The DateTimePicker will now display the title (and keep displaying the title, also after picking a date).

Previously the behaviour was to display the title when showing the picker, and after picking a date, it would display the date as the title. This is unnecessary since the date is shown directly below already, also in string representation. Additionally, when setting MinimumDate or MaximumDate in the DatePromptConfig, it would override the title and never show it, not even when the picker is shown.