### PR TITLE
fix UWP project bug

### DIFF
--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -86,6 +86,7 @@
         <Compile Include="Platforms\Uwp\ActionSheetViewModel.cs" />
         <Compile Include="Platforms\Uwp\Infrastructure\**\*.cs" />
         <Compile Include="Platforms\Uwp\Extensions.cs" />
+        <Compile Include="Platforms\Uwp\UserDialogs.cs" />
         <Compile Include="Platforms\Uwp\UserDialogsImpl.cs" />
         <Compile Include="Platforms\Uwp\ActionSheetContentDialog.xaml.cs">
             <DependentUpon>Platforms\Uwp\ActionSheetContentDialog.xaml</DependentUpon>


### PR DESCRIPTION
There's a bug in the project file that `UserDialogs` is not included to compile for UWP target framework. Lack of compiling this file results in missing of `UserDialogs.Instance`  in the DLL and UWP APP crashes.

this pull request fixes this problem.