### PR TITLE
Fixed threading issue with AndHUD

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/ProgressDialog.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/ProgressDialog.cs
@@ -73,7 +73,7 @@ namespace Acr.UserDialogs
             this.IsShowing = false;
             try
             {
-                AndHUD.Shared.Dismiss();
+                AndHUD.Shared.Dismiss(activity);
             }
             catch(Exception exc)
             {
@@ -113,8 +113,6 @@ namespace Acr.UserDialogs
             if (this.config.OnCancel != null)
                 txt += "\n" + this.config.CancelText;
 
-            // I'll help out andhud here
-            this.activity.SafeRunOnUi(() =>
                 AndHUD.Shared.Show(
                     this.activity,
                     txt,
@@ -122,8 +120,7 @@ namespace Acr.UserDialogs
                     this.config.MaskType.ToNative(),
                     null,
                     this.OnCancelClick
-                )
-            );
+                );
         }
 
 


### PR DESCRIPTION
1) Also send the activity to AndHUD when dismissing so that it has a fallback option to dismiss the dialog.
2) Remove the UI thread invoker around the Show method. AndHUD has fixed that in its own code and not having the showing and the dismissing following the same threading logic, causes race conditions.
Threading in AndHUD: https://github.com/Redth/AndHUD/blob/master/AndHUD/AndHUD.cs#L298 

This has fixed an issue I was experiencing when using  AcrDialogs in an async method.