### PR TITLE
Update to AndHUD 1.4.1

### DIFF
--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -56,17 +56,10 @@
         <Compile Include="Platforms\Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid81' ">
         <Compile Include="Platforms\Shared\**\*.cs" />
         <Compile Include="Platforms\Android\**\*.cs" />
-        <PackageReference Include="AndHUD" Version="1.2.0" />
-        <PackageReference Include="Xamarin.Android.Support.Design" Version="25.4.0.2" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
-        <Compile Include="Platforms\Shared\**\*.cs" />
-        <Compile Include="Platforms\Android\**\*.cs" />
-        <PackageReference Include="AndHUD" Version="1.2.0" />
+        <PackageReference Include="AndHUD" Version="1.4.1" />
         <PackageReference Include="Xamarin.Android.Support.Design" Version="26.1.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
Had to ditch the old MonoAndroid70 and MonoAndroid80 targets. They are not
supported in the Play Store anyways.

Fixes #582 