### PR TITLE
[UWP] Date and Time dialogs aren't centered #334

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
@@ -303,12 +303,17 @@ namespace Acr.UserDialogs
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center
             };
+            // popup.LayoutUpdated += Popup_LayoutUpdated;
+            // TODO: This is a workaround because sender is null when subscribing to the event
+            popup.LayoutUpdated += (sender, e) =>
+            {
+                Popup_LayoutUpdated(popup, e);
+            };
             if (element != null)
                 popup.Child = element;
 
             return popup;
         }
-
 
         protected virtual DateTime GetDateForCalendar(CalendarView calendar)
             => calendar.SelectedDates.Any()
@@ -447,6 +452,25 @@ namespace Acr.UserDialogs
 
             this.dispatcher.Invoke(dispatch);
             return disposer;
+        }
+        #endregion
+
+        #region Privates
+
+        private static void Popup_LayoutUpdated(object sender, object e)
+        {
+            if (sender is Popup popup && popup.Child is Control control &&
+                control.ActualWidth != 0 && control.ActualHeight != 0)
+            {
+                var newHorizontalOffset = (int)(Window.Current.Bounds.Width - control.ActualWidth) / 2;
+                var newVerticalOffset = (int)(Window.Current.Bounds.Height - control.ActualHeight) / 2;
+
+                if (popup.HorizontalOffset != newHorizontalOffset || popup.VerticalOffset != newVerticalOffset)
+                {
+                    popup.HorizontalOffset = newHorizontalOffset;
+                    popup.VerticalOffset = newVerticalOffset;
+                }
+            }
         }
         #endregion
     }


### PR DESCRIPTION
Fix for the issue #334,  based on this solution https://stackoverflow.com/a/19051399/3546760 with some refactoring.

Tried to subscribe to the event like this:

```
popup.LayoutUpdated += Popup_LayoutUpdated;
```

but the sender was null so I ended up passing the sender manually

```
popup.LayoutUpdated += (sender, e) =>
{
    Popup_LayoutUpdated(popup, e);
};
```

I guess it's a bug in UWP, so until it fixed we should use this workaround. I also wrote a TODO in the code explaining the issue and that it should be changed when they fix the bug.

Tested only on Windows 10, version 10.0.17763.0