### PR TITLE
Add NegativeSign to list of acceptable input characters

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
@@ -162,7 +162,7 @@ namespace Acr.UserDialogs.Builders
                 case InputType.DecimalNumber:
                     txt.InputType = InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned;
                     txt.SetSingleLine(true);
-                    txt.KeyListener = DigitsKeyListener.GetInstance("1234567890" + CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+                    txt.KeyListener = DigitsKeyListener.GetInstance($"1234567890{CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator}{CultureInfo.CurrentCulture.NumberFormat.NegativeSign}");
                     break;
 
                 case InputType.Email:


### PR DESCRIPTION
When specifying the InputType.DecimalNumber as the input to the prompt dialog.

Fixes #263