### PR TITLE
Readme: Updated MvvmCross initalization example code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ To use, simply reference the nuget package in each of your platform projects.
 
     UserDialogs.Init(this);
     OR UserDialogs.Init(() => provide your own top level activity provider)
-    OR MvvmCross - UserDialogs.Init(() => Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity)
+    OR MvvmCross - UserDialogs.Init(() => Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>().Activity)
     OR Xamarin.Forms - UserDialogs.Init(() => this);
 
 ### MvvmCross


### PR DESCRIPTION
The MvvmCross API has changed, `Mvx.Resolve` is deprecated. `Mvx.IoCProvider.Resolve` should be used instead.