### PR TITLE
change text wrapping in uwp

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
@@ -275,7 +275,7 @@ namespace Acr.UserDialogs
                     {
                         Message = config.Message,
                         //Stretch = Stretch.Fill,
-                        TextWrapping = TextWrapping.Wrap,
+                        TextWrapping = TextWrapping.WrapWholeWords,
                         MillisecondsUntilHidden = Convert.ToInt32(config.Duration.TotalMilliseconds)
                     };
                     if (config.Icon != null)


### PR DESCRIPTION
Message and Icon is not in the same line 
change text wrapping to fix this