### PR TITLE
Adding a fix for #637

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/Fragments/ConfigStore.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/Fragments/ConfigStore.cs
@@ -23,7 +23,7 @@ namespace Acr.UserDialogs.Fragments
         }
 
 
-        public bool Contains(Bundle bundle) => bundle?.ContainsKey(this.BundleKey) ?? false;
+        public bool Contains(Bundle bundle) => configStore.ContainsKey(bundle?.GetLong(BundleKey, -1) ?? -1);
 
 
         //public bool TryPop<T>(Bundle bundle, out T config) where T : class


### PR DESCRIPTION
### Description of Change ###

Changing `ConfigStore.Contains(Bundle)` to check for presence of the config key in its local dictionary instead of only checking whether the bundle contains the config store key.

I wanted to keep this a oneliner, and I just realized that makes the code look a bit hacky. I'll expand it into a method body if that suits you better.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #637 

### API Changes ###
None
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Follow the testing procedure in #637 and verify there is no crash. I'm currently short on time and have trouble building on my Mac but I'll test myself later if required.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard