### PR TITLE
Change InputType in Android LoginBuilder; fixes #400

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/Builders/LoginBuilder.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/Builders/LoginBuilder.cs
@@ -22,7 +22,7 @@ namespace Acr.UserDialogs.Builders
             var txtUser = new EditText(activity)
             {
                 Hint = config.LoginPlaceholder,
-                InputType = InputTypes.TextVariationVisiblePassword,
+                InputType = InputTypes.ClassText,
                 Text = config.LoginValue ?? String.Empty
             };
             txtUser.SetSingleLine(true);
@@ -66,7 +66,7 @@ namespace Acr.UserDialogs.Builders
             var txtUser = new EditText(activity)
             {
                 Hint = config.LoginPlaceholder,
-                InputType = InputTypes.TextVariationVisiblePassword,
+                InputType = InputTypes.ClassText,
                 Text = config.LoginValue ?? String.Empty
             };
             txtUser.SetSingleLine(true);


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
I think issue #400 can be fixed by changing of InputType on username field. `TextVariationVisiblePassword` is intended for password and not username. I guess `ClassText` would be better.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #400 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard