### PR TITLE
Add service for loading images from alternate locations

### DIFF
--- a/src/Acr.UserDialogs/IResourceResolver.cs
+++ b/src/Acr.UserDialogs/IResourceResolver.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.IO;
+
+namespace Acr.UserDialogs
+{
+    public interface IResourceResolver
+    {
+        Stream FromName(string name);
+    }
+}

--- a/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
@@ -184,7 +184,19 @@ namespace Acr.UserDialogs
                     ShowOnTop = cfg.Position == ToastPosition.Top
                 };
                 if (cfg.Icon != null)
-                    snackbar.Icon = UIImage.FromBundle(cfg.Icon);
+                {
+                    if (ToastConfig.DefaultImageResolver != null)
+                    {
+                        using (var stream = ToastConfig.DefaultImageResolver.FromName(cfg.Icon))
+                        {
+                            if (null != stream)
+                                using (var imageData = NSData.FromStream(stream))
+                                    snackbar.Icon = UIImage.LoadFromData(imageData);
+                        }
+                    }
+                    else
+                        snackbar.Icon = UIImage.FromBundle(cfg.Icon);
+                }
 
                 if (cfg.BackgroundColor != null)
                     snackbar.BackgroundColor = cfg.BackgroundColor.Value.ToNative();

--- a/src/Acr.UserDialogs/ToastConfig.cs
+++ b/src/Acr.UserDialogs/ToastConfig.cs
@@ -28,6 +28,8 @@ namespace Acr.UserDialogs
 
         public static ToastPosition? DefaultPosition { get; set; }
 
+        public static IResourceResolver DefaultImageResolver { get; set; }
+
         public string Message { get; set; }
         public Color? MessageTextColor { get; set; } = DefaultMessageTextColor;
         public Color? BackgroundColor { get; set; } = DefaultBackgroundColor;


### PR DESCRIPTION
### Description of Change ###

On iOS, Toast notifications can have an icon. The icon is specified by name, and resolved from within the app bundle.
When using Xamarin.Forms, one may wish to have images resolved using another manner, such as embedded resources within the Forms assembly to share image resources across all platform apps.
This change adds ToastConfig.DefaultImageResolver, which is an injectable service that maps a resource name, to a System.Stream.

### API Changes ###
New:
ToastConfig.DefaultImageResolver: Static default resolver instance. Can be null.
IResourceResolver - contract definition with single method: "FromName" - returns a Stream of an image, given a symbolic name.
No concrete implementation provided nor needed. When null, falls back to "UIImage.FromBundle".

### Platforms Affected ### 
- iOS

### Behavioural Changes ###
None

### Testing Procedure ###
Create a default implementation, and register it with ToastConfig.

```
ToastConfig.DefaultImageResolver = new EmbeddedResourceImageResolver();

class EmbeddedResourceImageResolver : IImageResolver
{
    public Stream FromResourceName(string name)
    {
        return GetType().Assembly.GetManifestResourceStream($"MyAssembly.Resources.{name}");
    }
}

// show toast with icon
handle = userDialogs.Toast(new ToastConfig("Unable to contact the server.")
        .SetIcon("embedded-resource.png"));
```