### PR TITLE
fix invisible text iOS 13 dark mode date picker

### DIFF
--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -34,9 +34,10 @@ namespace AI
         public AIDatePickerController()
         {
 #if __IOS__
-            this.BackgroundColor = (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-                ? UIColor.TertiarySystemBackgroundColor
-                : UIColor.White;
+            bool isDarkMode = this.TraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark;
+            UIColor altTextColor = isDarkMode ? UIColor.Black : UIColor.TertiarySystemBackgroundColor;
+            bool isv13 = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+            this.BackgroundColor = isv13 ? altTextColor : UIColor.White;
 #else
             this.BackgroundColor = UIColor.White;
 #endif


### PR DESCRIPTION
## Description of Change ###

use black text when in dark mode, tertiary color becomes white which fades into white background (this technically does not add support for dark mode, but only fixes a bug with disappearing text)

### Issues Resolved ### 
addresses #699 but does not fully resolve it

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral Changes ###
None

### Testing Procedure ###
The date picker should be tested on iOS >= v13 in dark mode.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard