### PR TITLE
Fixed ShowOnTop using Toasts Sample

### DIFF
--- a/src/Samples/Samples/ViewModels/ToastsViewModel.cs
+++ b/src/Samples/Samples/ViewModels/ToastsViewModel.cs
@@ -108,7 +108,7 @@ namespace Samples.ViewModels
                 if (this.showOnTop == value)
                     return;
 
-                this.showOnTop = true;
+                this.showOnTop = value;
                 this.OnPropertyChanged();
             }
         }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes a bug in the sample app, using Toasts, for when the user activates ShowOnTop switch, it can't turn it off

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None (sample only)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
1. Open the app
2. Navigate to Toasts tab
3. Click Show On Top
4. Click it again

The app should let user to turn this switch off

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard