### PR TITLE
Added the possibility to control margins on Toasts

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/UserDialogsImpl.cs
@@ -137,17 +137,14 @@ namespace Acr.UserDialogs
                 if (cfg.BackgroundColor != null)
                     snackBar.View.SetBackgroundColor(cfg.BackgroundColor.Value.ToNative());
 
-                if (cfg.Position == ToastPosition.Top)
+                var layoutParams = snackBar.View.LayoutParameters as FrameLayout.LayoutParams;
+                if (layoutParams != null)
                 {
-                    // watch for this to change in future support lib versions
-                    var layoutParams = snackBar.View.LayoutParameters as FrameLayout.LayoutParams;
-                    if (layoutParams != null)
-                    {
-                        layoutParams.Gravity = GravityFlags.Top;
-                        layoutParams.SetMargins(0, 80, 0, 0);
-                        snackBar.View.LayoutParameters = layoutParams;
-                    }
+                    layoutParams.Gravity = cfg.Position == ToastPosition.Top ? GravityFlags.Top : GravityFlags.Bottom;
+                    layoutParams.SetMargins(cfg.LeftMargin ?? 0, cfg.TopMargin ?? 80, cfg.RightMargin ?? 0, cfg.BottomMargin ?? 0);
+                    snackBar.View.LayoutParameters = layoutParams;
                 }
+
                 if (cfg.Action != null)
                 {
                     snackBar.SetAction(cfg.Action.Text, x =>

--- a/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
@@ -183,6 +183,19 @@ namespace Acr.UserDialogs
                     AnimationType = TTGSnackbarAnimationType.FadeInFadeOut,
                     ShowOnTop = cfg.Position == ToastPosition.Top
                 };
+
+                if (cfg.LeftMargin.HasValue)
+                    snackbar.LeftMargin = cfg.LeftMargin.Value;
+
+                if (cfg.TopMargin.HasValue)
+                    snackbar.TopMargin = cfg.TopMargin.Value;
+
+                if (cfg.RightMargin.HasValue)
+                    snackbar.RightMargin = cfg.RightMargin.Value;
+
+                if (cfg.BottomMargin.HasValue)
+                    snackbar.BottomMargin = cfg.BottomMargin.Value;
+
                 if (cfg.Icon != null)
                     snackbar.Icon = UIImage.FromBundle(cfg.Icon);
 

--- a/src/Acr.UserDialogs/ToastConfig.cs
+++ b/src/Acr.UserDialogs/ToastConfig.cs
@@ -36,6 +36,10 @@ namespace Acr.UserDialogs
         public ToastAction Action { get; set; }
         public string Icon { get; set; }
 
+        public int? LeftMargin { get; set; }
+        public int? TopMargin { get; set; }
+        public int? RightMargin { get; set; }
+        public int? BottomMargin { get; set; }
 
         public ToastConfig(string message)
         {
@@ -95,6 +99,16 @@ namespace Acr.UserDialogs
         public ToastConfig SetIcon(string icon)
         {
             this.Icon = icon;
+            return this;
+        }
+
+        public ToastConfig SetMargin(int? left, int? top, int? right, int? bottom)
+        {
+            this.LeftMargin = left;
+            this.TopMargin = top;
+            this.RightMargin = right;
+            this.BottomMargin = bottom;
+
             return this;
         }
     }

--- a/src/Samples/Samples/Pages/ToastsPage.xaml
+++ b/src/Samples/Samples/Pages/ToastsPage.xaml
@@ -18,6 +18,16 @@
                     <SwitchCell Text="Show On Top" On="{Binding ShowOnTop}" />
 <!--                    <EntryCell Label="Background Color" Text="{Binding BackgroundColor}" />-->
                     <EntryCell Label="Duration (sec)" Text="{Binding SecondsDuration}" Keyboard="Numeric" />
+                </TableSection>
+
+                <TableSection Title="Margin">
+                    <EntryCell Label="Left Margin" Text="{Binding LeftMargin}" Keyboard="Numeric" />
+                    <EntryCell Label="Top Margin" Text="{Binding TopMargin}" Keyboard="Numeric" />
+                    <EntryCell Label="Right Margin" Text="{Binding RightMargin}" Keyboard="Numeric" />
+                    <EntryCell Label="Bottom Margin" Text="{Binding BottomMargin}" Keyboard="Numeric" />
+                </TableSection>
+
+                <TableSection Title="Action">
                     <TextCell Text="Open Toast" Command="{Binding Open}" />
                 </TableSection>
             </TableRoot>

--- a/src/Samples/Samples/ViewModels/ToastsViewModel.cs
+++ b/src/Samples/Samples/ViewModels/ToastsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using Acr.UserDialogs;
 using Xamarin.Forms;
@@ -19,6 +19,11 @@ namespace Samples.ViewModels
             this.MessageTextColor = ToHex(Color.White);
             this.BackgroundColor = ToHex(Color.Blue);
 
+            this.LeftMargin = 0;
+            this.TopMargin = 0;
+            this.RightMargin = 0;
+            this.BottomMargin = 0;
+
             this.Open = new Command(() =>
             {
                 // var icon = await BitmapLoader.Current.LoadFromResource("emoji_cool_small.png", null, null);
@@ -35,6 +40,7 @@ namespace Samples.ViewModels
                     //.SetMessageTextColor(msgColor)
                     .SetDuration(TimeSpan.FromSeconds(this.SecondsDuration))
                     .SetPosition(this.ShowOnTop ? ToastPosition.Top : ToastPosition.Bottom)
+                    .SetMargin(this.LeftMargin, this.TopMargin, this.RightMargin, this.BottomMargin)
                     //.SetIcon(icon)
                     .SetAction(x => x
                         .SetText(this.ActionText)
@@ -94,6 +100,66 @@ namespace Samples.ViewModels
                     return;
 
                 this.secondsDuration = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+
+        int leftMargin;
+        public int LeftMargin
+        {
+            get => this.leftMargin;
+            set
+            {
+                if (this.leftMargin == value)
+                    return;
+
+                this.leftMargin = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+
+        int topMargin;
+        public int TopMargin
+        {
+            get => this.topMargin;
+            set
+            {
+                if (this.topMargin == value)
+                    return;
+
+                this.topMargin = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+
+        int rightMargin;
+        public int RightMargin
+        {
+            get => this.rightMargin;
+            set
+            {
+                if (this.rightMargin == value)
+                    return;
+
+                this.rightMargin = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+
+        int bottomMargin;
+        public int BottomMargin
+        {
+            get => this.bottomMargin;
+            set
+            {
+                if (this.bottomMargin == value)
+                    return;
+
+                this.bottomMargin = value;
                 this.OnPropertyChanged();
             }
         }


### PR DESCRIPTION
### Description of Change ###

The toast component appears on top of the Tab Bar when used with bottom orientation, and on top of the Navigation Bar when used with top orientation. This PR adds the possibility for the user control margins to show the toast.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- None

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

There's a change in the Sample app inside Toasts tab, that allows user to test values for the toasts to appear.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard