### PR TITLE
Fix crash on iOS 12 and make color selection consistent on tvOS

### DIFF
--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -33,14 +33,7 @@ namespace AI
 
         public AIDatePickerController()
         {
-#if __IOS__
-            bool isDarkMode = this.TraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark;
-            UIColor altTextColor = isDarkMode ? UIColor.Black : UIColor.TertiarySystemBackgroundColor;
-            bool isv13 = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
-            this.BackgroundColor = isv13 ? altTextColor : UIColor.White;
-#else
-            this.BackgroundColor = UIColor.White;
-#endif
+            this.BackgroundColor = GetBackgroundColor();
             //this.ModalPresentationStyle = UIModalPresentationStyle.Custom;
             this.ModalPresentationStyle = UIModalPresentationStyle.OverCurrentContext;
             this.TransitioningDelegate = this;
@@ -270,6 +263,31 @@ namespace AI
 		{
 			return this;
 		}
+
+        private UIColor GetBackgroundColor()
+        {
+            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+            {
+                if (this.TraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark)
+                {
+                    return UIColor.Black;
+                }
+#if __IOS__
+                else if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+                {
+                    return UIColor.TertiarySystemBackgroundColor;
+                }
+#endif
+                else
+                {
+                    return UIColor.White;
+                }
+            }
+            else
+            {
+                return UIColor.White;
+            }
+        }
 	}
 }
 


### PR DESCRIPTION
### Description of Change ###

fe9d16d86928e9ec5e0bf856cea3ce833932deb8 fixed crashes with iOS<13 but #718 regressed these changes, resulting in a crash when opening the date picker on iOS<13 because `UIColor.TertiarySystemBackgroundColor` is not available on iOS<12. This attempts to resolve that crash, applies some additional checks that should help with iOS<12 (`UIUserInterfaceStyle.Dark` isn't available on iOS<12), and applies the same `UIUserInterfaceStyle.Dark` checks for tvOS.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- Addresses a regression with a previous fix to #699 but doesn't address the issue beyond that.

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Will set date picker background color to black on iOS12 if `this.TraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark` when the date picker is created.

### Testing Procedure ###
Test that date picker works on iOS<12, iOS12, iOS13 and tvOS, with dark mode enabled and disabled. I tested iOS12 and iOS13 dark/light modes, so at minimum there shouldn't be any regressions.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard