### PR TITLE
Datepicker on iOS: Update colors when prompt is open and dark mode is turned on/off

### DIFF
--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Cryptography;
 using Acr.UserDialogs;
 using Foundation;
 using UIKit;
@@ -33,7 +34,7 @@ namespace AI
 
         public AIDatePickerController()
         {
-            this.BackgroundColor = GetBackgroundColor();
+            SetTheme();
             //this.ModalPresentationStyle = UIModalPresentationStyle.Custom;
             this.ModalPresentationStyle = UIModalPresentationStyle.OverCurrentContext;
             this.TransitioningDelegate = this;
@@ -263,6 +264,24 @@ namespace AI
 		{
 			return this;
 		}
+
+        public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+        {
+            base.TraitCollectionDidChange(previousTraitCollection);
+
+            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+            {
+                if (this.TraitCollection.UserInterfaceStyle != previousTraitCollection.UserInterfaceStyle)
+                {
+                    SetTheme();
+                }
+            }
+        }
+
+        private void SetTheme()
+        {
+            this.BackgroundColor = GetBackgroundColor();
+        }
 
         private UIColor GetBackgroundColor()
         {

--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
 using Acr.UserDialogs;
 using Foundation;
 using UIKit;


### PR DESCRIPTION
### Description of Change ###

Before this PR, the dark mode setting was respected but only when showing the view controller. Changes to the setting while the controller was visible where not respected.

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

None

### Testing Procedure ###
See video.

![datepicker](https://user-images.githubusercontent.com/1481801/92951688-12a38c00-f45f-11ea-9187-8247c3463259.gif)

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard