### PR TITLE
#753 - Time and Date dialogs crash in iOS <= 12

### DIFF
--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -268,7 +268,7 @@ namespace AI
         {
             base.TraitCollectionDidChange(previousTraitCollection);
 
-            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0) && previousTraitCollection != null)
             {
                 if (this.TraitCollection.UserInterfaceStyle != previousTraitCollection.UserInterfaceStyle)
                 {


### PR DESCRIPTION
### Description of Change ###

Added null check for previousTraitCollection in AIDatePickerController's TraitCollectionDidChange method.

### Issues Resolved ### 

- fixes #753 - Time and Date dialogs crash in iOS <= 12

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

None

### Testing Procedure ###
Run Samples.iOS project on simulator running iOS <= 12 and test Date and Time prompts

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard