### PR TITLE
#757 Android - In PromptBuilder set "No suggestion"-Flag if InputType.Password

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using Android.App;
 using Android.Content;
@@ -187,11 +187,12 @@ namespace Acr.UserDialogs.Builders
 
                 case InputType.NumericPassword:
                     txt.TransformationMethod = PasswordTransformationMethod.Instance;
-                    txt.InputType = InputTypes.ClassNumber;
+                    txt.InputType = InputTypes.ClassNumber | InputTypes.TextFlagNoSuggestions;
                     break;
 
                 case InputType.Password:
                     txt.TransformationMethod = PasswordTransformationMethod.Instance;
+                    txt.InputType = InputTypes.TextFlagNoSuggestions;
                     //txt.InputType = InputTypes.ClassText | InputTypes.TextVariationPassword;
                     break;
 


### PR DESCRIPTION
### Description of Change ###

When using InputType.Password or InputType.NumericPassword in PromptConfig this change prevents Android to present suggestions based on earlier entries.
This could become critical when prompt dialog is used to request a password.

### Issues Resolved ### 
fixes #757 -> [Enhancement] Android - In PromptBuilder set "No suggestion"-Flag if InputType.Password

### API Changes ###
 None

### Platforms Affected ### 
Android

### Behavioral Changes ###
When a prompt dialog is presented, with this change no suggestions based on earlier entries will be presented if InputType of PromptConfig is NumericPassword or Password.

### Testing Procedure ###
Open a prompt dialog with InputType.Password or InputType.NumericPassword and enter "123456". Close dialog. Open same prompt dialog again. No suggestions by Android will be made.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard