### PR TITLE
changed DebugType to portable

### DIFF
--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -34,8 +34,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DebugType Condition=" !$(TargetFramework.StartsWith('monoandroid')) ">portable</DebugType>
-        <DebugType Condition=" $(TargetFramework.StartsWith('monoandroid')) ">full</DebugType>
+        <DebugType>portable</DebugType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/src/Samples/Samples.Droid/Samples.Droid.csproj
+++ b/src/Samples/Samples.Droid/Samples.Droid.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -44,7 +44,7 @@
     <AndroidSupportedAbis />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>


### PR DESCRIPTION
### Description of Change ###

attempt to fix #756 by changing the `DebugType` from `full` to `portable` for all platforms (reverts the change added in 6953dd1695fcb032011178fd2253751451c42f3b )

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #756 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

compile the app in Preview of VS2019 16.9 and the warning about deprecated debug symbol is gone

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard