### PR TITLE
Fix for issue #768

### DIFF
--- a/src/Acr.UserDialogs/DatePromptConfig.cs
+++ b/src/Acr.UserDialogs/DatePromptConfig.cs
@@ -9,7 +9,7 @@ namespace Acr.UserDialogs
         public static string DefaultCancelText { get; set; } = "Cancel";
         public static DateTimeKind DefaultUnspecifiedDateTimeKindReplacement { get; set; } = DateTimeKind.Local;
         public static int? DefaultAndroidStyleId { get; set; }
-        public static iOSDatePickerStyle? DefaultiOSDatePickerStyle { get; set; }
+        public static iOSPickerStyle? DefaultiOSDatePickerStyle { get; set; }
 
         public string Title { get; set; }
         public string OkText { get; set; } = DefaultOkText;
@@ -23,6 +23,6 @@ namespace Acr.UserDialogs
         public DateTime? MinimumDate { get; set; }
         public DateTime? MaximumDate { get; set; }
         public int? AndroidStyleId { get; set; } = DefaultAndroidStyleId;
-        public iOSDatePickerStyle? iOSDatePickerStyle { get; set; } = DefaultiOSDatePickerStyle;
+        public iOSPickerStyle? iOSPickerStyle { get; set; } = DefaultiOSDatePickerStyle;
     }
 }

--- a/src/Acr.UserDialogs/IiOSStyleDialogConfig.cs
+++ b/src/Acr.UserDialogs/IiOSStyleDialogConfig.cs
@@ -2,6 +2,6 @@
 {
     public interface IiOSStyleDialogConfig
     {
-        iOSDatePickerStyle? iOSDatePickerStyle { get; set; }
+        iOSPickerStyle? iOSPickerStyle { get; set; }
     }
 }

--- a/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/AIDatePickerController.cs
@@ -14,7 +14,7 @@ namespace AI
 #if __IOS__
 		public UIDatePickerMode Mode { get; set; } = UIDatePickerMode.Date;
 #endif
-		public iOSDatePickerStyle DatePickerStyle { get; set; }
+		public iOSPickerStyle PickerStyle { get; set; }
 		public UIColor BackgroundColor { get; set; }
         public DateTime SelectedDateTime { get; set; } = DateTime.Now;
         public DateTime? MaximumDateTime { get; set; }
@@ -58,7 +58,7 @@ namespace AI
                 MinuteInterval = MinuteInterval
 			};
 
-			SetPreferredDatePickerStyle(ref datePicker,DatePickerStyle);
+			SetPreferredDatePickerStyle(ref datePicker,PickerStyle);
 
             if (Use24HourClock == true)
                 datePicker.Locale = NSLocale.FromLocaleIdentifier("NL");
@@ -312,7 +312,7 @@ namespace AI
         }
 
 #if __IOS__
-		private void SetPreferredDatePickerStyle(ref UIDatePicker datePicker, iOSDatePickerStyle? style)
+		private void SetPreferredDatePickerStyle(ref UIDatePicker datePicker, iOSPickerStyle? style)
         {
 			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 4) ||
 				datePicker == null ||
@@ -321,7 +321,7 @@ namespace AI
 				return;
 			}
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0) && style.Value == iOSDatePickerStyle.Compact)
+			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0) && style.Value == iOSPickerStyle.Compact)
 			{
 				datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Compact;
 				return;
@@ -329,9 +329,9 @@ namespace AI
 
 			switch (style.Value)
             {
-				case iOSDatePickerStyle.Auto: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Automatic; return;
-				case iOSDatePickerStyle.Inline: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Inline; return;
-				case iOSDatePickerStyle.Wheels: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels; return;
+				case iOSPickerStyle.Auto: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Automatic; return;
+				case iOSPickerStyle.Inline: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Inline; return;
+				case iOSPickerStyle.Wheels: datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels; return;
 			}
 
 			datePicker.PreferredDatePickerStyle = UIDatePickerStyle.Automatic;

--- a/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
@@ -52,7 +52,7 @@ namespace Acr.UserDialogs
             {
 #if __IOS__
                 Mode = UIDatePickerMode.Date,
-                DatePickerStyle = GetPickerStyle(config),
+                PickerStyle = GetPickerStyle(config),
 #endif
                 SelectedDateTime = config.SelectedDate ?? DateTime.Now,
                 OkText = config.OkText,
@@ -76,6 +76,7 @@ namespace Acr.UserDialogs
             {
 #if __IOS__
                 Mode = UIDatePickerMode.Time,
+                PickerStyle = GetPickerStyle(config),
 #endif
                 SelectedDateTime = config.SelectedTime != null ? DateTime.Today.Add ((TimeSpan)config.SelectedTime) : DateTime.Now,
                 MinuteInterval = config.MinuteInterval,
@@ -334,16 +335,16 @@ namespace Acr.UserDialogs
             }
         }
 
-        protected iOSDatePickerStyle GetPickerStyle(DatePromptConfig config)
+        protected iOSPickerStyle GetPickerStyle(IiOSStyleDialogConfig config)
         {
-            var iOSConfig = (config as IiOSStyleDialogConfig);
-            if (iOSConfig == null)
-                return iOSDatePickerStyle.Auto;
+            //var iOSConfig = (config as IiOSStyleDialogConfig);
+            if (config == null)
+                return iOSPickerStyle.Auto;
 
-            if (!iOSConfig.iOSDatePickerStyle.HasValue)
-                return iOSDatePickerStyle.Auto;
+            if (!config.iOSPickerStyle.HasValue)
+                return iOSPickerStyle.Auto;
 
-            return iOSConfig.iOSDatePickerStyle.Value;
+            return config.iOSPickerStyle.Value;
         }
 
         #endregion

--- a/src/Acr.UserDialogs/TimePromptConfig.cs
+++ b/src/Acr.UserDialogs/TimePromptConfig.cs
@@ -3,13 +3,14 @@
 
 namespace Acr.UserDialogs
 {
-    public class TimePromptConfig : IAndroidStyleDialogConfig
+    public class TimePromptConfig : IAndroidStyleDialogConfig, IiOSStyleDialogConfig
     {
         public static string DefaultOkText { get; set; } = "Ok";
         public static string DefaultCancelText { get; set; } = "Cancel";
         public static int DefaultMinuteInterval { get; set; } = 1;
         public static bool? DefaultUse24HourClock { get; set; }
         public static int? DefaultAndroidStyleId { get; set; }
+        public static iOSPickerStyle? DefaultiOSTimePickerStyle { get; set; }
 
         public string Title { get; set; }
         public string OkText { get; set; } = DefaultOkText;
@@ -38,5 +39,6 @@ namespace Acr.UserDialogs
         public int MinuteInterval { get; set; } = DefaultMinuteInterval;
 
         public int? AndroidStyleId { get; set; } = DefaultAndroidStyleId;
+        public iOSPickerStyle? iOSPickerStyle { get; set; } = DefaultiOSTimePickerStyle;
     }
 }

--- a/src/Acr.UserDialogs/iOSPickerStyle.cs
+++ b/src/Acr.UserDialogs/iOSPickerStyle.cs
@@ -1,6 +1,6 @@
 ﻿namespace Acr.UserDialogs
 {
-    public enum iOSDatePickerStyle
+    public enum iOSPickerStyle
     {
         Auto,
         Inline,


### PR DESCRIPTION
### Description of Change ###

I've exposed the dialog style selector for the iOS time picker

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #768 

### API Changes ###
Added picker style properties to TimePickerConfig
Passed values to the Controller for use in the presentation code
 
### Platforms Affected ### 
- iOS

### Behavioral Changes ###
Allows the consuming application to show time dialogs in iOS 14 as wheel pickers.

### Testing Procedure ###
Run the test iOS application and specify ```iOSPickerStyle = iOSPickerStyle.Wheels``` in the config options
