### PR TITLE
Implemented AutoCorrect Configuration for Prompts

### DIFF
--- a/src/Acr.UserDialogs/AutoCorrectionConfig.cs
+++ b/src/Acr.UserDialogs/AutoCorrectionConfig.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Acr.UserDialogs
+{
+    public enum AutoCorrectionConfig
+    {
+        Default,
+        No,
+        Yes
+    }
+}

--- a/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/Builders/PromptBuilder.cs
@@ -38,6 +38,21 @@ namespace Acr.UserDialogs.Builders
 
             SetInputType(txt, config.InputType);
 
+            if (config.AutoCorrectionConfig != AutoCorrectionConfig.Default)
+            {
+                switch (config.AutoCorrectionConfig)
+                {
+                    case AutoCorrectionConfig.No:
+                        txt.InputType |= InputTypes.TextFlagNoSuggestions; // Add Flag
+                        break;
+                    case AutoCorrectionConfig.Yes:
+                        txt.InputType &= ~InputTypes.TextFlagNoSuggestions; // Remove Flag
+                        break;
+                    default:
+                        break;
+                }
+            }
+
             var builder = new AlertDialog.Builder(activity, config.AndroidStyleId ?? 0)
                 .SetCancelable(false)
                 .SetMessage(config.Message)
@@ -76,6 +91,21 @@ namespace Acr.UserDialogs.Builders
                 txt.SetFilters(new[] { new InputFilterLengthFilter(config.MaxLength.Value) });
 
             SetInputType(txt, config.InputType);
+
+            if (config.AutoCorrectionConfig != AutoCorrectionConfig.Default)
+            {
+                switch(config.AutoCorrectionConfig)
+                {
+                    case AutoCorrectionConfig.No:
+                        txt.InputType |= InputTypes.TextFlagNoSuggestions; // Add Flag
+                        break;
+                    case AutoCorrectionConfig.Yes:
+                        txt.InputType &= ~InputTypes.TextFlagNoSuggestions; // Remove Flag
+                        break;
+                    default:
+                        break;
+                }
+            }
 
             var builder = new AppCompatAlertDialog.Builder(activity, config.AndroidStyleId ?? 0)
                 .SetCancelable(false)

--- a/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
@@ -137,6 +137,7 @@ namespace Acr.UserDialogs
                 this.SetInputType(txt, config.InputType);
                 txt.Placeholder = config.Placeholder ?? String.Empty;
                 txt.Text = config.Text ?? String.Empty;
+                txt.AutocorrectionType = (UITextAutocorrectionType)config.AutoCorrectionConfig;
 
                 if (config.MaxLength != null)
                 {

--- a/src/Acr.UserDialogs/PromptConfig.cs
+++ b/src/Acr.UserDialogs/PromptConfig.cs
@@ -24,6 +24,7 @@ namespace Acr.UserDialogs
         public int? MaxLength { get; set; } = DefaultMaxLength;
         public int? AndroidStyleId { get; set; } = DefaultAndroidStyleId;
         public InputType InputType { get; set; } = InputType.Default;
+        public AutoCorrectionConfig AutoCorrectionConfig { get; set; } = AutoCorrectionConfig.Default;
         //public bool UwpCancelOnEscKey { get; set; }
         //public bool UwpSubmitOnEnterKey { get; set; }
         public Action<PromptTextChangedArgs> OnTextChanged { get; set; }

--- a/src/Samples/Samples/ViewModels/StandardViewModel.cs
+++ b/src/Samples/Samples/ViewModels/StandardViewModel.cs
@@ -174,6 +174,19 @@ namespace Samples.ViewModels
                 },
                 new CommandViewModel
                 {
+                    Text = "Prompt NoAutoCorrect",
+                    Command = new Command(async () =>
+                    {
+                        var result = await this.Dialogs.PromptAsync(new PromptConfig
+                        {
+                            Title = "Prompt NoAutoCorrect",
+                            Message = "When entering text, the keyboard should not provide autocorrect options",
+                            AutoCorrectionConfig = AutoCorrectionConfig.No
+                        });
+                    })
+                },
+                new CommandViewModel
+                {
                     Text = "Prompt AutoCorrect",
                     Command = new Command(async () =>
                     {

--- a/src/Samples/Samples/ViewModels/StandardViewModel.cs
+++ b/src/Samples/Samples/ViewModels/StandardViewModel.cs
@@ -174,6 +174,19 @@ namespace Samples.ViewModels
                 },
                 new CommandViewModel
                 {
+                    Text = "Prompt AutoCorrect",
+                    Command = new Command(async () =>
+                    {
+                        var result = await this.Dialogs.PromptAsync(new PromptConfig
+                        {
+                            Title = "Prompt AutoCorrect",
+                            Message = "When entering text, the keyboard should provide autocorrect options",
+                            AutoCorrectionConfig = AutoCorrectionConfig.Yes
+                        });
+                    })
+                },
+                new CommandViewModel
+                {
                     Text = "Date",
                     Command = this.Create(async token =>
                     {
@@ -210,6 +223,7 @@ namespace Samples.ViewModels
                     })
                 }
             };
+            Console.WriteLine("Test");
         }
 
 

--- a/src/Samples/Samples/ViewModels/StandardViewModel.cs
+++ b/src/Samples/Samples/ViewModels/StandardViewModel.cs
@@ -236,7 +236,6 @@ namespace Samples.ViewModels
                     })
                 }
             };
-            Console.WriteLine("Test");
         }
 
 


### PR DESCRIPTION
### Description of Change ###

Implemented support for defining AutoCorrect behavior in prompts.

### Issues Resolved ### 
None

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android

### Behavioral Changes ###
The default AutoCorrectionConfig is .Default, which doesn't alter any behavior.

### Testing Procedure ###
The sample app has been updated to have a Autocorrect Prompt and NoAutocorrect prompt option, which has been used during development.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard