### PR TITLE
Adding ability to scroll when the Action Sheet options is too long, c…

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Uwp/ActionSheetContentDialog.xaml
+++ b/src/Acr.UserDialogs/Platforms/Uwp/ActionSheetContentDialog.xaml
@@ -8,33 +8,33 @@
     Title="{Binding Title}"
     mc:Ignorable="d">
     <ContentDialog.Content>
-        <StackPanel>
-            <TextBlock Text="{Binding Message}" FontSize="12" Visibility="{Binding MessageVisibility}" />
-            <!--Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">-->
-            <ListBox x:Name="List" ItemsSource="{Binding Options}" SelectionMode="Single">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Horizontal">
-                            <Image Source="{Binding ItemIcon}" />
-                            <TextBlock Text="{Binding Text}" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button
+        <ScrollViewer>
+            <StackPanel>
+                <TextBlock Text="{Binding Message}" FontSize="12" Visibility="{Binding MessageVisibility}" />
+                <!--Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">-->
+                <ListBox x:Name="List" ItemsSource="{Binding Options}" SelectionMode="Single">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <Image Source="{Binding ItemIcon}" />
+                                <TextBlock Text="{Binding Text}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <Button
                     DataContext="{Binding Destructive}"
                     Content="{Binding Text}"
                     Command="{Binding Action}"
-                    Visibility="{Binding Visible}"
-                />
-                <Button
+                    Visibility="{Binding Visible}" />
+                    <Button
                     DataContext="{Binding Cancel}"
                     Content="{Binding Text}"
                     Command="{Binding Action}"
-                    Visibility="{Binding Visible}"
-                />
+                    Visibility="{Binding Visible}" />
+                </StackPanel>
             </StackPanel>
-        </StackPanel>
+        </ScrollViewer>
     </ContentDialog.Content>
 </ContentDialog>


### PR DESCRIPTION
…reating an issue were the cancel button and other options are unreachable in UWP.

### Description of Change ###

I wrapped the StackPanel in on a ScrollViewer for the Content of ContentDialog for UWP.

### Issues Resolved ### 
I wasn't able to create an issue for this! But it fixes the issue where if there is too many 'options' in the Action Sheet, you won't be able to reach them or the buttons.

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral Changes ###
When there is not enough items to have a Scroll Option, it won't appear. meaning there is no behavioral changes unless there is a very long list. Examples below:

Normal:
![Screenshot (27)](https://user-images.githubusercontent.com/22222178/117025453-88938680-acc0-11eb-97c6-aad1a49137c5.png)
Long List:
![Screenshot (26)](https://user-images.githubusercontent.com/22222178/117025503-90ebc180-acc0-11eb-961a-1d51d07720a3.png)

### Testing Procedure ###
I created both a short and long list of options to display in the ActionSheet, and made sure the short list behaves just as before (no ScrollBar) while the long list is able to scroll down to the button.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard