### PR TITLE
Allow user to press Enter to submit value on UWP

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
@@ -237,6 +237,7 @@ namespace Acr.UserDialogs
             {
                 Title = config.Title ?? String.Empty,
                 Content = stack,
+                DefaultButton = ContentDialogButton.Primary,
                 PrimaryButtonText = config.OkText
             };
 


### PR DESCRIPTION
### Description of Change ###
This allows the user to press the Enter key to submit their values.
If the user is entering a value on the keyboard, it is natural to press the Enter key to finish the entry.
The ContentDialog.DefaultButton property was introduced in Windows 10, version 1703 (build 15063).
Acr.UserDialogs currently requires a minimum of build 16299.

### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral Changes ###
The Enter key will become functional, hopefully reducing end-user frustration.

### Testing Procedure ###
I created a subclass of UserDialogsImpl and overrode the Prompt() method in my local UWP project and it worked well.  I am not currently setup to build the Acr.UserDialogs library.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard