### PR TITLE
Select existing text when displaying prompt on UWP

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Uwp/UserDialogsImpl.cs
@@ -371,6 +371,8 @@ namespace Acr.UserDialogs
 
             stack.Children.Add(txt);
 
+            txt.SelectAll();
+
             dialog.PrimaryButtonCommand = new Command(() =>
             {
                 config.OnAction?.Invoke(new PromptResult(true, txt.Text.Trim()));


### PR DESCRIPTION
### Description of Change ###
Previously, the cursor defaulted to the start of the text, which made it difficult to erase the text and start over.
Many apps reduce this effort by selecting the existing text when displaying a prompt.

### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral Changes ###
The pre-populated text in the dialog will be selected, hopefully reducing end-user frustration.

### Testing Procedure ###
I created a subclass of UserDialogsImpl and overrode the SetDefaultPrompt() method in my local UWP project and it worked well.  I am not currently setup to build the Acr.UserDialogs library.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard