### PR TITLE
Fix iOS 15 Crashes

### DIFF
--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -8,7 +8,7 @@
         <Authors>Allan Ritchie</Authors>
         <Description>A cross platform library that allows you to call for standard user dialogs from a shared/portable library. Supports Android, iOS, and UWP</Description>
         <PackageTags>windows ios android xamarin xam.pcl dialogs plugin</PackageTags>
-        <VersionPrefix>7.1.0</VersionPrefix>
+        <VersionPrefix>7.1.1</VersionPrefix>
         <VersionPrefix Condition=" $(BUILD_BUILDNUMBER) != '' ">$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
         <PackageReleaseNotes>https://github.com/aritchie/userdialogs/raw/master/ChangeLog.md</PackageReleaseNotes>
         <PackageIconUrl>https://github.com/aritchie/userdialogs/raw/master/icon.png</PackageIconUrl>
@@ -77,7 +77,7 @@
         <Compile Include="Platforms\Shared\**\*.cs" />
         <Compile Include="Platforms\ios\**\*.cs" />
         <Compile Include="Platforms\Apple\**\*.cs" />
-        <PackageReference Include="BTProgressHUD" Version="1.3.1" />
+        <PackageReference Include="BTProgressHUD" Version="1.3.4" />
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.tvos')) ">

--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -8,7 +8,7 @@
         <Authors>Allan Ritchie</Authors>
         <Description>A cross platform library that allows you to call for standard user dialogs from a shared/portable library. Supports Android, iOS, and UWP</Description>
         <PackageTags>windows ios android xamarin xam.pcl dialogs plugin</PackageTags>
-        <VersionPrefix>7.1.1</VersionPrefix>
+        <VersionPrefix>7.1.0</VersionPrefix>
         <VersionPrefix Condition=" $(BUILD_BUILDNUMBER) != '' ">$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
         <PackageReleaseNotes>https://github.com/aritchie/userdialogs/raw/master/ChangeLog.md</PackageReleaseNotes>
         <PackageIconUrl>https://github.com/aritchie/userdialogs/raw/master/icon.png</PackageIconUrl>

--- a/src/Acr.UserDialogs/Platforms/ios/Extensions.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/Extensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-#if __IOS__
-using BigTed;
-#endif
 using Foundation;
 using UIKit;
 using Acr.UserDialogs.Infrastructure;
@@ -28,14 +25,14 @@ namespace Acr.UserDialogs
 
 #if __IOS__
 
-        public static ProgressHUD.MaskType ToNative(this MaskType maskType)
+        public static BTProgressHUD.MaskType ToNative(this MaskType maskType)
         {
             switch (maskType)
             {
-                case MaskType.Black: return ProgressHUD.MaskType.Black;
-                case MaskType.Clear: return ProgressHUD.MaskType.Clear;
-                case MaskType.Gradient: return ProgressHUD.MaskType.Gradient;
-                case MaskType.None: return ProgressHUD.MaskType.None;
+                case MaskType.Black: return BTProgressHUD.MaskType.Black;
+                case MaskType.Clear: return BTProgressHUD.MaskType.Clear;
+                case MaskType.Gradient: return BTProgressHUD.MaskType.Gradient;
+                case MaskType.None: return BTProgressHUD.MaskType.None;
                 default:
                     throw new ArgumentException("Invalid mask type");
             }

--- a/src/Acr.UserDialogs/Platforms/ios/ProgressDialog.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/ProgressDialog.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-#if __IOS__
-using BigTed;
-#endif
 using UIKit;
 
 
@@ -71,7 +68,7 @@ namespace Acr.UserDialogs
         {
             this.IsShowing = false;
 #if __IOS__
-            UIApplication.SharedApplication.InvokeOnMainThread(BTProgressHUD.Dismiss);
+            UIApplication.SharedApplication.InvokeOnMainThread(BTProgressHUD.BTProgressHUD.Dismiss);
 #endif
         }
 
@@ -110,7 +107,7 @@ namespace Acr.UserDialogs
                 if (this.config.OnCancel == null)
                 {
 #if __IOS__
-                    BTProgressHUD.Show(
+                    BTProgressHUD.BTProgressHUD.Show(
                         this.Title,
                         p,
                         this.config.MaskType.ToNative()
@@ -120,7 +117,7 @@ namespace Acr.UserDialogs
                 else
                 {
 #if __IOS__
-                    BTProgressHUD.Show(
+                    BTProgressHUD.BTProgressHUD.Show(
                         this.config.CancelText,
                         this.config.OnCancel,
                         txt,


### PR DESCRIPTION
Update BTProgressHUD to v1.3.4 to fix iOS 15 crashes

<!-- Describe your changes here. -->

### Issues Resolved ### 

- Fixes crashes on iOS 15 originated in the BTProgressHUD library. More info can be found on [Issue #84](https://github.com/redth-org/BTProgressHUD/issues/84)


### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

None

### Testing Procedure ###
Test that the app doesn't crash on IOS 15. Most of my observed crashes were when the app was on background or doing background fetch. 

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard