### PR TITLE
Android - Build dialog fragment on UI thread

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Android/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/Android/UserDialogsImpl.cs
@@ -280,9 +280,10 @@ namespace Acr.UserDialogs
 
         protected virtual IDisposable ShowDialog<TFragment, TConfig>(AppCompatActivity activity, TConfig config) where TFragment : AbstractAppCompatDialogFragment<TConfig> where TConfig : class, new()
         {
-            var frag = (TFragment)Activator.CreateInstance(typeof(TFragment));
+            TFragment frag = null;
             activity.SafeRunOnUi(() =>
             {
+                frag = (TFragment)Activator.CreateInstance(typeof(TFragment));
                 frag.Config = config;
                 frag.Show(activity.SupportFragmentManager, FragmentTag);
             });


### PR DESCRIPTION
### Description of Change ###
The Show method above already build the dialog on the UI thread but the ShowDialog doesn't. Ensure that it is also the case for the ShowDialog method.

### Issues Resolved ### 
This modification fix the following exception reported in our production logs
> Java.Lang.IllegalStateException: Method addObserver must be called on the main thread

The complete stacktrace of the crash
```cs
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
  at object System.Reflection.RuntimeConstructorInfo.InternalInvoke(object obj, object[] parameters, bool wrapExceptions)
  at object RuntimeType.CreateInstanceMono(bool nonPublic, bool wrapExceptions)
  at object RuntimeType.CreateInstanceSlow(bool publicOnly, bool wrapExceptions, bool skipCheckThis, bool fillCache)
  at object RuntimeType.CreateInstanceDefaultCtor(bool publicOnly, bool skipCheckThis, bool fillCache, bool wrapExceptions, ref StackCrawlMark stackMark)
  at object Activator.CreateInstance(Type type, bool nonPublic, bool wrapExceptions) x 3
  at IDisposable Acr.UserDialogs.UserDialogsImpl.ShowDialog<AlertAppCompatDialogFragment, AlertConfig>(AppCompatActivity activity, AlertConfig config)
  at IDisposable Acr.UserDialogs.UserDialogsImpl.Alert(AlertConfig config)
  at async Task Acr.UserDialogs.AbstractUserDialogs.AlertAsync(AlertConfig config, CancellationToken? cancelToken)
```

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral Changes ###
None

### Testing Procedure ###
Run the Android sample

### PR Checklist ###
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard