### PR TITLE
Use BTProgressHUD 1.3.5

### DIFF
--- a/src/Acr.UserDialogs/Acr.UserDialogs.csproj
+++ b/src/Acr.UserDialogs/Acr.UserDialogs.csproj
@@ -78,7 +78,7 @@
         <Compile Include="Platforms\Shared\**\*.cs" />
         <Compile Include="Platforms\ios\**\*.cs" />
         <Compile Include="Platforms\Apple\**\*.cs" />
-        <PackageReference Include="BTProgressHUD" Version="1.3.4" />
+        <PackageReference Include="BTProgressHUD" Version="1.3.5" />
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.tvos')) ">

--- a/src/Acr.UserDialogs/Platforms/ios/Extensions.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/Extensions.cs
@@ -25,14 +25,14 @@ namespace Acr.UserDialogs
 
 #if __IOS__
 
-        public static BTProgressHUD.MaskType ToNative(this MaskType maskType)
+        public static BigTed.MaskType ToNative(this MaskType maskType)
         {
             switch (maskType)
             {
-                case MaskType.Black: return BTProgressHUD.MaskType.Black;
-                case MaskType.Clear: return BTProgressHUD.MaskType.Clear;
-                case MaskType.Gradient: return BTProgressHUD.MaskType.Gradient;
-                case MaskType.None: return BTProgressHUD.MaskType.None;
+                case MaskType.Black: return BigTed.MaskType.Black;
+                case MaskType.Clear: return BigTed.MaskType.Clear;
+                case MaskType.Gradient: return BigTed.MaskType.Gradient;
+                case MaskType.None: return BigTed.MaskType.None;
                 default:
                     throw new ArgumentException("Invalid mask type");
             }

--- a/src/Acr.UserDialogs/Platforms/ios/ProgressDialog.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/ProgressDialog.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if __IOS__
+using BigTed;
+#endif
 using UIKit;
 
 
@@ -68,7 +71,7 @@ namespace Acr.UserDialogs
         {
             this.IsShowing = false;
 #if __IOS__
-            UIApplication.SharedApplication.InvokeOnMainThread(BTProgressHUD.BTProgressHUD.Dismiss);
+            UIApplication.SharedApplication.InvokeOnMainThread(BTProgressHUD.Dismiss);
 #endif
         }
 
@@ -107,7 +110,7 @@ namespace Acr.UserDialogs
                 if (this.config.OnCancel == null)
                 {
 #if __IOS__
-                    BTProgressHUD.BTProgressHUD.Show(
+                    BTProgressHUD.Show(
                         this.Title,
                         p,
                         this.config.MaskType.ToNative()
@@ -117,7 +120,7 @@ namespace Acr.UserDialogs
                 else
                 {
 #if __IOS__
-                    BTProgressHUD.BTProgressHUD.Show(
+                    BTProgressHUD.Show(
                         this.config.CancelText,
                         this.config.OnCancel,
                         txt,


### PR DESCRIPTION
### Description of Change ###
This PR fixes incompatibility between Acr.UserDialogs and BTProgressHUD v1.3.5.

BTProgressHUD version 1.3.5 contains stability improvements for iOS 15. Unfortunately, due namespace changes, it will not work (compile) with the latest Acr.UserDialogs.

### Issues Resolved###
- More stability fixes for iOS 15: https://github.com/redth-org/BTProgressHUD/issues/84#issuecomment-953911685


### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral Changes ###
None


### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard