### PR TITLE
Added DefaultUseYesNo to ConfirmConfig to switch between OK/Cancel and Yes/No globally

### DIFF
--- a/src/Acr.UserDialogs/ConfirmConfig.cs
+++ b/src/Acr.UserDialogs/ConfirmConfig.cs
@@ -6,6 +6,7 @@ namespace Acr.UserDialogs
 
     public class ConfirmConfig : IStandardDialogConfig, IAndroidStyleDialogConfig
     {
+        public static bool DefaultUseYesNo { get; set; }
         public static string DefaultYes { get; set; } = "Yes";
         public static string DefaultNo { get; set; } = "No";
         public static string DefaultOkText { get; set; } = "Ok";
@@ -20,8 +21,8 @@ namespace Acr.UserDialogs
         //public bool UwpCancelOnEscKey { get; set; }
         //public bool UwpSubmitOnEnterKey { get; set; }
 
-        public string OkText { get; set; } = DefaultOkText;
-        public string CancelText { get; set; } = DefaultCancelText;
+        public string OkText { get; set; } = !DefaultUseYesNo ? DefaultOkText : DefaultYes;
+        public string CancelText { get; set; } = !DefaultUseYesNo ? DefaultCancelText : DefaultNo;
 
 
         public ConfirmConfig UseYesNo()


### PR DESCRIPTION
### Description of Change ###

When using a `ConfirmDialog` without setting any arguments, its buttons default to `DefaultOkText` and `DefaultCancelText` and this behavior cannot be changed in anyway. So the only option *was* to always use `UseYesNo`. With these changes one can now set the property `DefaultUseYesNo` to `true` (`false` by default to ensure no changes in existing code) to have the `ConfirmDialog` buttons default to `DefaultYes` and `DefaultNo` instead.

### Issues Resolved ###

None

### API Changes ###

A new static property `DefaultUseYesNo` was added (`false` by default to ensure no changes in existing code) that can be set to `true` to have the `ConfirmDialog` buttons default to `DefaultYes` and `DefaultNo` instead of  `DefaultOkText` and `DefaultCancelText`.

### Platforms Affected ###

- All

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard