### PR TITLE
Change preprocessor symbol from .NET Standard to .NET 8 in Shared/UserDialogs.cs

### DIFF
--- a/src/Acr.UserDialogs/Platforms/Shared/UserDialogs.cs
+++ b/src/Acr.UserDialogs/Platforms/Shared/UserDialogs.cs
@@ -5,7 +5,7 @@ namespace Acr.UserDialogs
 {
     public static partial class UserDialogs
     {
-        #if NETSTANDARD
+        #if NET8_0
         static IUserDialogs currentInstance;
         public static IUserDialogs Instance
         {


### PR DESCRIPTION
Change preprocessor symbol from .NET Standard to .NET 8

### Description of Change ###

Change preprocessor symbol from .NET Standard symbol to .NET 8 symbol

### Issues Resolved ### 
Static Instance property was not usable anymore since dropping .NET Standard in .NET 8 (or even .NET 6) class library projects.

### API Changes ###
 None

### Platforms Affected ### 

- All

### Behavioral Changes ###

None

### Testing Procedure ###
/

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard