### PR TITLE
Check if PopoverPresentationController is null

### DIFF
--- a/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
+++ b/src/Acr.UserDialogs/Platforms/ios/UserDialogsImpl.cs
@@ -272,15 +272,20 @@ namespace Acr.UserDialogs
             {
                 alert = alertFunc();
                 var top = this.viewControllerFunc();
-                if (alert.PreferredStyle == UIAlertControllerStyle.ActionSheet && UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+                if (alert.PreferredStyle == UIAlertControllerStyle.ActionSheet &&
+                    UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad &&
+                    top is { View: not null })
                 {
                     var x = top.View.Bounds.Width / 2;
                     var y = top.View.Bounds.Bottom;
                     var rect = new CGRect(x, y, 0, 0);
 #if __IOS__
-                    alert.PopoverPresentationController.SourceView = top.View;
-                    alert.PopoverPresentationController.SourceRect = rect;
-                    alert.PopoverPresentationController.PermittedArrowDirections = UIPopoverArrowDirection.Unknown;
+                    if (alert.PopoverPresentationController != null)
+                    {
+                        alert.PopoverPresentationController.SourceView = top.View;
+                        alert.PopoverPresentationController.SourceRect = rect;
+                        alert.PopoverPresentationController.PermittedArrowDirections = UIPopoverArrowDirection.Unknown;
+                    }
 #endif
                 }
                 top.PresentViewController(alert, true, null);


### PR DESCRIPTION
When the iPadOS application is executing on macOS on an M-series Mac, the PopoverPresentationController is null. Need to guard against this case.

### Description of Change ###

Guard for null references in the `Present(Func<UIAlertController> alertFunc)` method. As you can see in the PR, it only adds null checks so the risk of the change is low.

The fix is similar to what the MAUI team had to do to fix the same issue of ActionSheet not working on iPadOS apps running on macOS: https://github.com/dotnet/maui/pull/19629 and https://github.com/dotnet/maui/pull/19629#pullrequestreview-2124950796.

The [Apple documentation](https://developer.apple.com/documentation/uikit/uiviewcontroller/popoverpresentationcontroller) states that the `PopoverPresentationController` may be nil:

> If the view controller or one of its ancestors is managed by a popover presentation controller, this property contains that object. This property is nil if the view controller is not managed by a popover presentation controller.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

The position of the Action Sheet when running an iPadOS on macOS might change compared to running the iPadOS on iPad.

### Testing Procedure ###

I have tested this fix in this fork of UserDialogs: https://github.com/Alex-Dobrynin/Controls.UserDialogs.Maui/pull/33. Testing it is a bit involved, as you need to build an iPadOS, and then publish it to TestFlight to have it run on your macOS computer.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard